### PR TITLE
Update which filename is checked for BinExport

### DIFF
--- a/src/main/java/bindiffhelper/BinDiffHelperProvider.java
+++ b/src/main/java/bindiffhelper/BinDiffHelperProvider.java
@@ -244,7 +244,7 @@ public class BinDiffHelperProvider extends ComponentProviderAdapter {
 			Msg.showInfo(this, getComponent(), "Info", "Unexpected filename ending (expected .BinDiff)");
 		}
 		
-		String pname = program.getName().toString();
+		String pname = program.getDomainFile().getName().toString();
 		
 		BinExport2File[] bi = new BinExport2File[2];
 		int loadedProgramIndex = -1;
@@ -273,7 +273,7 @@ public class BinDiffHelperProvider extends ComponentProviderAdapter {
 						return;
 					}
 					
-					if (pname.equals(filenames[i][1]))
+					if (pname.equals(filenames[i][0]))
 					{
 						loadedProgramIndex = i;
 					


### PR DESCRIPTION
Usually the filename and the exefilename in the BinDiff file is the
same, however I noticed when using BinDiff's export plugin, it names the
binexport file based on the value found in the filename field, not the
exefilename.  Additionally, the program name as gotten by
program.getName() may not match the filename as well.  Using the
"domain file" seems to fix this issue.