### PR TITLE
Show functions that are only on one side

### DIFF
--- a/src/main/java/bindiffhelper/BinExport2File.java
+++ b/src/main/java/bindiffhelper/BinExport2File.java
@@ -3,6 +3,7 @@ package bindiffhelper;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.HashMap;
+import java.util.Set;
 
 import com.google.security.zynamics.BinExport.BinExport2;
 import com.google.security.zynamics.BinExport.BinExport2.CallGraph;
@@ -27,6 +28,10 @@ public class BinExport2File {
 		{
 			functionNames.put(v.getAddress(), v.getMangledName());
 		}
+	}
+	
+	public Set<Long> getFunctionAddressSet(){
+		return functionNames.keySet();
 	}
 	
 	public boolean hasFunctionName(long address)

--- a/src/main/java/bindiffhelper/ComparisonTableModel.java
+++ b/src/main/java/bindiffhelper/ComparisonTableModel.java
@@ -17,6 +17,7 @@ public class ComparisonTableModel extends AbstractTableModel {
     		"Address other file",
     		"Name other file",
     		"Similarity",
+    		"Confidence",
     		"Algorithm"
     };
     
@@ -54,20 +55,28 @@ public class ComparisonTableModel extends AbstractTableModel {
     	case 0:
     		return e.do_import;
     	case 1:
-    		return "0x" + Long.toHexString(e.primaryAddress.getUnsignedOffset());
+    		if(e.primaryAddress != null)
+    			return "0x" + Long.toHexString(e.primaryAddress.getUnsignedOffset());
+    		return "";
     	case 2:
     		if (e.primaryFunctionSymbol != null)
     			return e.primaryFunctionSymbol.getName();
     		return "No Symbol";
     	case 3:
-    		return e.primaryFunctionNameDb;
+    		if(e.primaryFunctionNameDb != null)
+    			return e.primaryFunctionNameDb;
+    		return "";
     	case 4:
     		return "0x" + Long.toHexString(e.secondaryAddress);
     	case 5:
-    		return e.secondaryFunctionName;
+    		if(e.secondaryFunctionName != null)
+    			return e.secondaryFunctionName;
+    		return "";
     	case 6:
     		return e.similarity;    	
     	case 7:
+    		return e.confidence;    	
+    	case 8:
     		return e.algorithm;
     	}
     	
@@ -113,9 +122,10 @@ public class ComparisonTableModel extends AbstractTableModel {
     	final long secondaryAddress;
     	final String secondaryFunctionName;
     	final double similarity;
+    	final double confidence;
     	final String algorithm;
     	
-    	public Entry(boolean i, Address pa, String pfn, Symbol pfs, long sa, String sfn, double sim, String alg)
+    	public Entry(boolean i, Address pa, String pfn, Symbol pfs, long sa, String sfn, double sim, double con, String alg)
     	{
     		do_import = i;
     		primaryAddress = pa;
@@ -124,6 +134,7 @@ public class ComparisonTableModel extends AbstractTableModel {
     		secondaryAddress = sa;
     		secondaryFunctionName = sfn;
     		similarity = sim;
+    		confidence = con;
     		algorithm = alg;
     	}
     	


### PR DESCRIPTION
In the table view, show functions that are only in the primary or
secondary in the table view.  Clicking on ones in the secondary is a bad
idea.  It will throw a null pointer exception.  The on-click handler
should probably pay attention and if the primary is null then do
nothing.