### PR TITLE
GHIDRA_INSTALL_DIR not GHIDRA_INSTALLATION_DIR

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -88,7 +88,7 @@ Requirements:
 * gradle (tested with 5.0 and 6.2.2)
 
 ### Build it
-You need to set the **GHIDRA_INSTALLATION_DIR** environment variable to the Ghidra installation dir.
+You need to set the **GHIDRA_INSTALL_DIR** environment variable to the Ghidra installation dir.
 If you have different JDKs installed, make sure the environment variable **JAVA_HOME** points to the one your Ghidra installation uses.
 
 The extension will be built for that Ghidra version specifically.


### PR DESCRIPTION
This is just a tiny readme fix.

The system env value is `GHIDRA_INSTALL_DIR` not `GHIDRA_INSTALLATION_DIR` as confirmed by the build file. https://github.com/ubfx/BinDiffHelper/blob/master/build.gradle#L56-L67