### PR TITLE
Support for Ghidra 10.3

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,9 @@ Check out the [BinDiff manual](https://www.zynamics.com/bindiff/manual/) to see 
 
 ## What it does / Changelog
 
+### v0.4.2
+* Update to support Ghidra 10.3
+
 ### v0.4.1
 * Update to support Gradle 7.5 and Ghidra 10.1
 

--- a/src/main/java/bindiffhelper/GeneralOpenDialog.java
+++ b/src/main/java/bindiffhelper/GeneralOpenDialog.java
@@ -116,16 +116,16 @@ public class GeneralOpenDialog extends DialogComponentProvider {
 				return;
 			}
 			
-			var files = plugin.callBinDiff(df);
-			
-			if (files != null) {
-				plugin.provider.openBinDiffDB(files[2].getAbsolutePath(), files[0], files[1]);
-			}
+			plugin.callBinDiff(df, files -> {
+				if (files != null) {
+					plugin.provider.openBinDiffDB(files[2].getAbsolutePath(), files[0], files[1]);
+				}
+				close();
+			});
 		}
 		else {
 			Msg.showError(this, getComponent(), "Error", "No valid selection");
+			close();
 		}
-		
-		close();
 	}
 }


### PR DESCRIPTION
It seems like in Ghidra 10.3, the `tool.showDialog` call is now blocking. This causes the plugin to hang before it has any chance to call binexport.