### PR TITLE
CI: monthly build, ability to manually trigger GitHub Actions for specific Ghidra versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest"')) }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,13 +15,7 @@ jobs:
     strategy:
       matrix:
         ghidra:
-          - "11.1.2"
-          - "11.1.1"
-          - "11.1"
-          - "11.0.3"
-          - "11.0.2"
-          - "11.0.1"
-          - "11.0"
+          - "latest"
 
     steps:
     - name: Clone Repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,11 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      ghidra_version:
+        description: 'Specify the Ghidra version(s) you want to build for (e.g. "latest", "10.1.5")'
+        required: true
+        default: '"latest"'
   schedule:
     - cron: '0 0 1 * *' # Monthly
 permissions:
@@ -14,8 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        ghidra:
-          - "latest"
+        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest"')) }}
 
     steps:
     - name: Clone Repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       ghidra_version:
-        description: 'Specify the Ghidra version(s) you want to build for (e.g. "latest", "10.1.5")'
+        description: 'Specify the Ghidra version(s) you want to build for (e.g. "latest", "11.0")'
         required: true
         default: '"latest"'
   schedule:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,10 @@
 name: Build
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1 * *' # Monthly
 permissions:
   contents: write
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest"')) }}
+        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.1.2","11.1.1","11.1","11.0.3","11.0.2","11.0.1","11.0"')) }}
 
     steps:
     - name: Clone Repository


### PR DESCRIPTION
Closes #21 

- Replaced compilation for multiple Ghidra versions with the latest version
- In addition to the change above, the ability to specify the version(s) when manually triggering GitHub Actions was added (so that anyone who wants support for their version of Ghidra from the latest master only needs to fork the repository and choose to build the desired version, perhaps this should be noted in README.md, idk)
- Added a monthly build (this is in case the current code became incompatible when building with the latest version of Ghidra or if something in the CI itself broke, like outdated versions of actions)