### PR TITLE
Sort results in ascending order of similarity

### DIFF
--- a/src/main/java/bindiffhelper/BinDiffHelperProvider.java
+++ b/src/main/java/bindiffhelper/BinDiffHelperProvider.java
@@ -312,7 +312,7 @@ public class BinDiffHelperProvider extends ComponentProviderAdapter {
 
 			ResultSet rs = stmt.executeQuery("SELECT address1, address2, similarity, confidence, name "
 					+ "FROM function JOIN functionalgorithm ON function.algorithm=functionalgorithm.id "
-					+ "ORDER BY similarity DESC");
+					+ "ORDER BY similarity ASC");
 
 			while (rs.next()) {
 


### PR DESCRIPTION
Closes #20

Having the ability to sort in the columns themselves may be valuable to someone

But in general, at least for me, it is enough that similarity results simply go not in descending order, but in ascending order

After all, when you compare several binaries, you usually only a few dozen out of hundreds functions that differ, and therefore you want to see only those that are only different, and not those that match, because those that match will be the overwhelming majority in most cases