### PR TITLE
CI, build.gradle: java updated to version 21

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
-        java-version: '17'
+        java-version: '21'
 
     - name: Install Gradle
       uses: gradle/actions/setup-gradle@v3

--- a/Readme.md
+++ b/Readme.md
@@ -105,7 +105,7 @@ Select the other file from the tree and click OK.
 Requirements:
 
 * Ghidra installation (https://ghidra-sre.org) or compiled from source
-* Some jdk. There might be certain restrictions depending on how your Ghidra was built and what other plugins you're using. I recommend using [Temurin 17 LTS](https://adoptium.net/temurin/releases/?version=17), as this currently seems to work with both BinExport and BinDiffHelper. 
+* Some jdk. There might be certain restrictions depending on how your Ghidra was built and what other plugins you're using. I recommend using [Temurin 21 LTS](https://adoptium.net/temurin/releases/?version=21), as this currently seems to work with both BinExport and BinDiffHelper. 
 * gradle (tested with 7.5, 8.10)
 
 ### Clone the repository

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'eclipse'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 


### PR DESCRIPTION
See: https://github.com/google/binexport/pull/138

You also need to wait until they approve the pull request and after that you will need to update the submodule so that the latest version can be successfully built.