### PR TITLE
build.gradle: exclude 'binexport' and '.github' from distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,3 +55,6 @@ else {
 tasks.named("copyDependencies").configure {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }
+
+buildExtension.exclude '.github/**'
+buildExtension.exclude 'binexport/**'

--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,6 @@ dependencies {
     implementation 'org.xerial:sqlite-jdbc:3.46.0.1'
 }
 
-jar {
-    exclude('binexport')
-}
-
 // Standard Ghidra extension Gradle code follows.
 //----------------------START "DO NOT MODIFY" SECTION------------------------------
 def ghidraInstallDir


### PR DESCRIPTION
We really don't need to include the binexport source code in the distribution, since it is not used in runtime and only takes up 2/3 of the archive size.