### PR TITLE
Ghidra 12.1.2 support + various dialog fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.4.2","11.4.1","11.4"')) }}
+        # ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.4.2","11.4.1","11.4"')) }}
+        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest"')) }}
 
     steps:
     - name: Clone Repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.4.2","11.4.1","11.4"')) }}
-        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest"')) }}
+        ghidra: ${{ fromJSON(format('[{0}]', inputs.ghidra_version || '"latest","11.4.2","11.4.1","11.4"')) }}
 
     steps:
     - name: Clone Repository

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "binexport"]
 	path = binexport
-	url = https://github.com/google/binexport.git
+	url = https://github.com/abd3lraouf-studios/binexport-ghidra-12.git

--- a/src/main/java/bindiffhelper/BinDiffHelperPlugin.java
+++ b/src/main/java/bindiffhelper/BinDiffHelperPlugin.java
@@ -105,13 +105,16 @@ public class BinDiffHelperPlugin extends ProgramPlugin {
 			
 		}
 
-		if (System.getProperty("os.name").toLowerCase().contains("win")) {
+		String os = System.getProperty("os.name").toLowerCase();
+		if (os.contains("win")) {
 			defaultBinPath = "C:\\Program Files\\BinDiff\\bin\\bindiff.exe";
 			defaultDiffCommand = "notepad++ -multiInst -nosession -lc -pluginMessage=compare \"$file1\" \"$file2\"";
-		}
-		if (System.getProperty("os.name").toLowerCase().contains("nix")) {
-			// defaultBinPath = "/opt/bindiff/bin/bindiff";
-			defaultDiffCommand = "x-terminal-emulator -e 'diff -u \"$file1\" \"$file2\"'";
+		} else if (os.contains("mac")) {
+			defaultBinPath = "/Applications/BinDiff/BinDiff.app/Contents/MacOS/bin/bindiff";
+			defaultDiffCommand = "opendiff \"$file1\" \"$file2\"";
+		} else { // Linux/BSD
+			defaultBinPath = "/opt/bindiff/bin/bindiff";
+			defaultDiffCommand = "meld \"$file1\" \"$file2\"";
 		}
 
 		binDiffBinary = Preferences.getProperty(BDBINPROPERTY, defaultBinPath);

--- a/src/main/java/bindiffhelper/BinDiffHelperPlugin.java
+++ b/src/main/java/bindiffhelper/BinDiffHelperPlugin.java
@@ -311,7 +311,7 @@ public class BinDiffHelperPlugin extends ProgramPlugin {
 	
 	public void updateDiffCommand(String cmd)
 	{
-		diffCommand = cmd == null || cmd.isEmpty() ? defaultDiffCommand : cmd;
+		diffCommand = cmd == null || cmd.isBlank() ? defaultDiffCommand : cmd;
 		Preferences.setProperty(DIFFCOMMAND, cmd);
 	}
 

--- a/src/main/java/bindiffhelper/BinDiffHelperProvider.java
+++ b/src/main/java/bindiffhelper/BinDiffHelperProvider.java
@@ -447,7 +447,14 @@ public class BinDiffHelperProvider extends ComponentProviderAdapter {
 
 						String command = plugin.diffCommand.replace("$file1", path1.toString()).replace("$file2",
 								path2.toString());
-						Runtime.getRuntime().exec(command);
+
+						if (System.getProperty("os.name").toLowerCase().contains("win")) {
+							String[] shellCommand = { "cmd.exe", "/c", command };
+							Runtime.getRuntime().exec(shellCommand);
+						} else {
+							String[] shellCommand = { "/bin/sh", "-c", command };
+							Runtime.getRuntime().exec(shellCommand);
+						}
 					} catch (Exception ex) {
 						Msg.showError(this, getComponent(), "Error", ex.getMessage());
 					}

--- a/src/main/java/bindiffhelper/DiffWizard.java
+++ b/src/main/java/bindiffhelper/DiffWizard.java
@@ -346,17 +346,13 @@ class FromProjectStep extends WizardStep<DiffWizardData> {
 		if (tp == null || tp.getSelectedItemCount() != 1)
 			return false;
 
-		if (tp.getSelectedDomainFolder() != null)
-			return false;
-
 		var df = tp.getSelectedDomainFile();
 		return df != null;
 	}
 
 	@Override
 	public boolean canFinish(DiffWizardData data) {
-		// TODO Auto-generated method stub
-		return false;
+		return isValid();
 	}
 
 	@Override
@@ -420,27 +416,19 @@ class Program2Step extends WizardStep<DiffWizardData> {
 
 	@Override
 	public boolean isValid() {
-		Msg.debug(this, "selected count = " + tp.getSelectedItemCount());
-		Msg.debug(this, "selected folder = " + tp.getSelectedDomainFolder());
-		Msg.debug(this, "selected file = " + tp.getSelectedDomainFile());
+		if (!cb.isSelected())
+			return true;
 
-		return true;
-		// if (!cb.isSelected())
-		// 	return true;
+		if (tp == null || tp.getSelectedItemCount() != 1)
+			return false;
 
-		// if (tp == null || tp.getSelectedItemCount() != 1)
-		// 	return false;
-
-		// if (tp.getSelectedDomainFolder() != null)
-		// 	return false;
-
-		// var df = tp.getSelectedDomainFile();
-		// return df != null;
+		var df = tp.getSelectedDomainFile();
+		return df != null;
 	}
 
 	@Override
 	public boolean canFinish(DiffWizardData data) {
-		return true;
+		return isValid();
 	}
 
 	@Override

--- a/src/main/java/bindiffhelper/DiffWizard.java
+++ b/src/main/java/bindiffhelper/DiffWizard.java
@@ -416,7 +416,7 @@ class Program2Step extends WizardStep<DiffWizardData> {
 
 	@Override
 	public boolean isValid() {
-		if (!cb.isSelected())
+		if (cb == null || !cb.isSelected())
 			return true;
 
 		if (tp == null || tp.getSelectedItemCount() != 1)

--- a/src/main/java/bindiffhelper/DiffWizard.java
+++ b/src/main/java/bindiffhelper/DiffWizard.java
@@ -408,6 +408,13 @@ class Program2Step extends WizardStep<DiffWizardData> {
 		this.panel.add(cb);
 		this.panel.add(tp);
 
+		cb.addActionListener(e -> notifyStatusChanged());
+		tp.addTreeSelectionListener(new GTreeSelectionListener() {
+			@Override
+			public void valueChanged(GTreeSelectionEvent e) {
+				notifyStatusChanged();
+			}
+		});
 	}
 
 

--- a/src/main/java/bindiffhelper/DiffWizard.java
+++ b/src/main/java/bindiffhelper/DiffWizard.java
@@ -420,9 +420,9 @@ class Program2Step extends WizardStep<DiffWizardData> {
 
 	@Override
 	public boolean isValid() {
-		Msg.showInfo(this, "selected count = " + tp.getSelectedItemCount());
-		Msg.showInfo(this, "selected folder = " + tp.getSelectedDomainFolder());
-		Msg.showInfo(this, "selected file = " + tp.getSelectedDomainFile());
+		Msg.debug(this, "selected count = " + tp.getSelectedItemCount());
+		Msg.debug(this, "selected folder = " + tp.getSelectedDomainFolder());
+		Msg.debug(this, "selected file = " + tp.getSelectedDomainFile());
 
 		return true;
 		// if (!cb.isSelected())

--- a/src/main/java/bindiffhelper/DiffWizard.java
+++ b/src/main/java/bindiffhelper/DiffWizard.java
@@ -420,17 +420,22 @@ class Program2Step extends WizardStep<DiffWizardData> {
 
 	@Override
 	public boolean isValid() {
-		if (!cb.isSelected())
-			return true;
+		Msg.showInfo(this, "selected count = " + tp.getSelectedItemCount());
+		Msg.showInfo(this, "selected folder = " + tp.getSelectedDomainFolder());
+		Msg.showInfo(this, "selected file = " + tp.getSelectedDomainFile());
 
-		if (tp == null || tp.getSelectedItemCount() != 1)
-			return false;
+		return true;
+		// if (!cb.isSelected())
+		// 	return true;
 
-		if (tp.getSelectedDomainFolder() != null)
-			return false;
+		// if (tp == null || tp.getSelectedItemCount() != 1)
+		// 	return false;
 
-		var df = tp.getSelectedDomainFile();
-		return df != null;
+		// if (tp.getSelectedDomainFolder() != null)
+		// 	return false;
+
+		// var df = tp.getSelectedDomainFile();
+		// return df != null;
 	}
 
 	@Override

--- a/src/main/java/bindiffhelper/DiffWizard.java
+++ b/src/main/java/bindiffhelper/DiffWizard.java
@@ -435,8 +435,7 @@ class Program2Step extends WizardStep<DiffWizardData> {
 
 	@Override
 	public boolean canFinish(DiffWizardData data) {
-		// TODO Auto-generated method stub
-		return false;
+		return true;
 	}
 
 	@Override
@@ -446,7 +445,7 @@ class Program2Step extends WizardStep<DiffWizardData> {
 
 	@Override
 	public boolean apply(DiffWizardData data) {
-		if (cb.isSelected()) {
+		if (data.useProgram2) {
 			try {
 				data.program2Df = tp.getSelectedDomainFile();
 				Tool newTool = plugin.getTool().getToolServices().launchDefaultTool(Collections.singletonList(data.program2Df));
@@ -465,7 +464,7 @@ class Program2Step extends WizardStep<DiffWizardData> {
 	public JComponent getComponent() {
 		return this.panel;
 	}
-	
+
 	@Override
 	public boolean isApplicable(DiffWizardData data) {
 		return !data.isFromProject;


### PR DESCRIPTION
Hi, I had to switch the binexport submodule to the third-party repo https://github.com/abd3lraouf-studios/binexport-ghidra-12 since the latest official version doesn't work on Ghidra 12. I guess you need to double check just in case.